### PR TITLE
feat: add role enum to user schema

### DIFF
--- a/server/models/User.js
+++ b/server/models/User.js
@@ -4,7 +4,11 @@ const userSchema = new mongoose.Schema({
   name: { type: String, required: true },
   email: { type: String, required: true, unique: true },
   passwordHash: { type: String, required: true },
-  role: { type: String, default: "user" },
+  role: {
+    type: String,
+    enum: ["Admin", "Manager", "Cleaner"],
+    default: "Cleaner",
+  },
   photoUrl: String,
 });
 


### PR DESCRIPTION
## Summary
- restrict user roles to `Admin`, `Manager`, or `Cleaner`
- default new users to `Cleaner`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68960f9a004c8333af2a0dcc0088eca9