### PR TITLE
feat: add role-based access middleware

### DIFF
--- a/server/middleware/requireRole.js
+++ b/server/middleware/requireRole.js
@@ -1,0 +1,10 @@
+function requireRole(role) {
+  return (req, res, next) => {
+    if (!req.user || req.user.role !== role) {
+      return res.status(403).json({ error: "Access denied" });
+    }
+    next();
+  };
+}
+
+module.exports = requireRole;

--- a/server/routes/customers.js
+++ b/server/routes/customers.js
@@ -1,6 +1,7 @@
 const express = require("express");
 const Customer = require("../models/Customer");
 const auth = require("../middleware/auth");
+const requireRole = require("../middleware/requireRole");
 
 const router = express.Router();
 
@@ -18,7 +19,7 @@ router.get("/", async (req, res) => {
 });
 
 // Create a customer
-router.post("/", async (req, res) => {
+router.post("/", requireRole("Admin"), async (req, res) => {
   try {
     const customer = new Customer(req.body);
     await customer.save();
@@ -42,7 +43,7 @@ router.get("/:id", async (req, res) => {
 });
 
 // Update a customer
-router.put("/:id", async (req, res) => {
+router.put("/:id", requireRole("Admin"), async (req, res) => {
   try {
     const customer = await Customer.findByIdAndUpdate(req.params.id, req.body, {
       new: true,


### PR DESCRIPTION
## Summary
- add reusable middleware to enforce user roles
- restrict customer creation and updates to admins only

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6896f86ee2c883338cc1815323c2949f