### PR TITLE
Add React AuthContext and hook

### DIFF
--- a/client/src/contexts/AuthContext.jsx
+++ b/client/src/contexts/AuthContext.jsx
@@ -1,0 +1,25 @@
+import { createContext, useState } from 'react';
+
+const AuthContext = createContext(null);
+
+export const AuthProvider = ({ children }) => {
+  const [user, setUser] = useState(null);
+
+  const login = (userData) => setUser(userData);
+  const logout = () => setUser(null);
+
+  const value = {
+    user,
+    login,
+    logout,
+    isAuthenticated: !!user,
+  };
+
+  return (
+    <AuthContext.Provider value={value}>
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+export default AuthContext;

--- a/client/src/hooks/useAuth.js
+++ b/client/src/hooks/useAuth.js
@@ -1,0 +1,12 @@
+import { useContext } from 'react';
+import AuthContext from '../contexts/AuthContext';
+
+const useAuth = () => {
+  const context = useContext(AuthContext);
+  if (context === undefined || context === null) {
+    throw new Error('useAuth must be used within an AuthProvider');
+  }
+  return context;
+};
+
+export default useAuth;


### PR DESCRIPTION
## Summary
- add AuthProvider to manage auth state in a React context
- create useAuth hook for consuming the auth context with provider check

## Testing
- `npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_6897a46dbf5083339ef183fb64200d92