### PR TITLE
Add login form component

### DIFF
--- a/client/src/components/LoginForm.jsx
+++ b/client/src/components/LoginForm.jsx
@@ -1,0 +1,41 @@
+import { useState } from 'react';
+import useAuth from '../hooks/useAuth';
+
+const LoginForm = () => {
+  const { login } = useAuth();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    login({ email, password });
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <div>
+        <label htmlFor="email">Email</label>
+        <input
+          type="email"
+          id="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+        />
+      </div>
+      <div>
+        <label htmlFor="password">Password</label>
+        <input
+          type="password"
+          id="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          required
+        />
+      </div>
+      <button type="submit">Login</button>
+    </form>
+  );
+};
+
+export default LoginForm;


### PR DESCRIPTION
## Summary
- add a simple login form with email and password fields

## Testing
- `cd server && npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6898489e27a0833391dc59f7fa6f66d6